### PR TITLE
fix(ci): Regex correctly matches tags when doing release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           VERSION=${GITHUB_REF/refs\/tags\//}
           echo ::set-output name=VERSION::${VERSION}
-          DOING_RELEASE=$(echo $VERSION | grep -c '[0-9]\+\.x' || true)
+          DOING_RELEASE=$(echo $VERSION | grep -c '^[0-9]\+\.x$' || true)
           echo ::set-output name=DOING_RELEASE::${DOING_RELEASE}
           echo Version: ${VERSION}
           echo Doing release: ${DOING_RELEASE}


### PR DESCRIPTION
Before this patch, a branch name like 10.x-testing-something was
considered as being the source of a release.

With this new regex we ensure we never use a wrong tag/branch to create
a release.