### PR TITLE
feat: Use the same Ubuntu version as Wasmer for `linux-amd64`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         target:
           - id: 'linux-amd64'
-            os: 'ubuntu-latest'
+            os: 'ubuntu-18.04'
             llvm_prefix: llvm-project/build/install
           #- id: 'linux-aarch64'
           #  os: ['self-hosted', 'linux', 'ARM64']


### PR DESCRIPTION
We have a linking issue for LLVM 11 on linux-amd64 on Wasmer. I believe it's because there is a difference between `ubuntu-latest` (aka `ubuntu-20.04`) used here, and `ubuntu-18.04` used by Wasmer.

So first, let's use the same environments!