### PR TITLE
Install headers on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,21 @@ jobs:
         target:
           - id: 'linux-amd64'
             os: 'ubuntu-18.04'
-            llvm_prefix: llvm-project/build/install
+            tar_extra_args: ''
           #- id: 'linux-aarch64'
           #  os: ['self-hosted', 'linux', 'ARM64']
-          #  llvm_prefix: llvm-project/build/install
           - id: 'darwin-amd64'
             os: 'macos-latest'
-            llvm_prefix: llvm-project/build/install
+            tar_extra_args: ''
           - id: 'windows-amd64'
             os: 'windows-2016'
-            llvm_prefix: llvm-project/build/Release
+            # When unpacking an archive on Windows, the symlinks can't be
+            # created unless the target path already exists. This causes
+            # problems when the linked file is ordered after the link
+            # inside the archive. Dereferencing the files when packing them
+            # adds an additional copy per link, but it reliably works and
+            # the additional size is not too large on Windows.
+            tar_extra_args: '--dereference'
         llvm_version: ['13.x']
         llvm_repo_url: ['https://github.com/llvm/llvm-project.git']
       fail-fast: true
@@ -66,15 +71,14 @@ jobs:
       - name: Inspect
         shell: bash
         run: |
-          ${{ matrix.target.llvm_prefix }}/bin/llvm-config --version
-          ${{ matrix.target.llvm_prefix }}/bin/clang --version
+          llvm-project/build/destdir/bin/llvm-config --version
+          llvm-project/build/destdir/bin/clang --version
 
       - name: Zip
         shell: bash
         run: |
-          mv ${{ matrix.target.llvm_prefix }} llvm-project/build/llvm
-          mkdir dist
-          tar -C llvm-project/build/llvm -cJvf dist/llvm.tar.xz .
+          mkdir -p dist
+          tar --directory llvm-project/build/destdir --create --xz --verbose ${{ matrix.target.tar_extra_args }} --file dist/llvm.tar.xz .
           ls -lh dist/llvm.tar.xz
 
       - name: Upload Artifacts

--- a/build.ps1
+++ b/build.ps1
@@ -39,7 +39,7 @@ $CMAKE_ARGUMENTS = ""
 cmake `
   -G "Visual Studio 15 2017 Win64" `
   -DCMAKE_BUILD_TYPE=MinSizeRel `
-  -DCMAKE_INSTALL_PREFIX=install `
+  -DCMAKE_INSTALL_PREFIX=destdir `
   -DLLVM_ENABLE_PROJECTS="clang;lld" `
   -DLLVM_ENABLE_TERMINFO=OFF `
   -DLLVM_ENABLE_ZLIB=OFF `
@@ -55,4 +55,11 @@ cmake `
   ../llvm
 
 # Showtime!
-cmake --build . --config Release --target INSTALL
+cmake --build . --config Release
+
+# Not using DESTDIR here, quote from
+# https://cmake.org/cmake/help/latest/envvar/DESTDIR.html
+# > `DESTDIR` may not be used on Windows because installation prefix
+# > usually contains a drive letter like in `C:/Program Files` which cannot
+# > be prepended with some other prefix.
+cmake --install . --strip --config Release

--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,7 @@ esac
 cmake \
   -G Ninja \
   -DCMAKE_BUILD_TYPE=MinSizeRel \
-  -DCMAKE_INSTALL_PREFIX="install" \
+  -DCMAKE_INSTALL_PREFIX="/" \
   -DLLVM_ENABLE_PROJECTS="clang;lld" \
   -DLLVM_ENABLE_TERMINFO=OFF \
   -DLLVM_ENABLE_ZLIB=OFF \
@@ -66,4 +66,5 @@ cmake \
   ../llvm
 
 # Showtime!
-ninja install
+cmake --build . --config Release
+DESTDIR=destdir cmake --install . --strip --config Release


### PR DESCRIPTION
Previus builds did not properly include the header files into the
Windows release. It appears the command that is used there doesn't
install them into the correct location:

`cmake --build . --config Release --target INSTALL`

CMake however includes its own install argument, and by using this the
headers are installed properly.

`cmake --install . --config Release`

Instead of using Ninja explicitly on non-Windows systems, this change
unifies the installation over all supported systems by using the same
command there as well.

This also allows to remove the `llvm_prefix` field from the github
actions file, because with the support of a `DESTDIR` environment
variable, the installations can be copied into the same output directory
on all systems.

Closes: #21