### PR TITLE
fix: use Release DCMAKE_BUILD_TYPE

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -45,7 +45,7 @@ $CMAKE_LINKER_TYPE="MSVC"
 
 cmake `
   -G "Ninja" `
-  -DCMAKE_BUILD_TYPE=MinSizeRel `
+  -DCMAKE_BUILD_TYPE=Release `
   -DCMAKE_INSTALL_PREFIX=destdir `
   -DLLVM_ENABLE_PROJECTS="clang;lld" `
   -DLLVM_ENABLE_TERMINFO=OFF `

--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ esac
 # Run `cmake` to configure the project.
 cmake \
   -G Ninja \
-  -DCMAKE_BUILD_TYPE=MinSizeRel \
+  -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX="/" \
   -DLLVM_ENABLE_PROJECTS="clang;lld" \
   -DLLVM_ENABLE_ZLIB=OFF \
@@ -76,8 +76,8 @@ cmake \
   ../llvm
 
 # Showtime!
-cmake --build . --config MinSizeRel
-DESTDIR=destdir cmake --install . --strip --config MinSizeRel
+cmake --build . --config Release
+DESTDIR=destdir cmake --install . --strip --config Release
 
 # move usr/bin/* to bin/ or llvm-config will be broken
 if [ ! -d destdir/bin ];then


### PR DESCRIPTION
So far, the LLVM was built as optimized for size what made the wasmer codegen much slower:
```
time target/release/wasmer run -l --disable-cache php/php-32 --compiler-threads=12 -- --version
real	0m33.667s
user	5m31.292s
```

After the change we get to the following numbers:
```
real	0m16.950s
user	3m16.750s
```

The binary size impact for wasmer CLI binary is about +20%.